### PR TITLE
Update example for vpsadminos compatibility

### DIFF
--- a/ct.nix
+++ b/ct.nix
@@ -7,7 +7,6 @@ in
 {
   imports = [
     <nixpkgs/nixos/modules/virtualisation/container-config.nix>
-    "${vpsadminos}/os/lib/nixos-container/build.nix"
-    "${vpsadminos}/os/lib/nixos-container/networking.nix"
+    "${vpsadminos}/os/lib/nixos-container/configuration.nix"
   ];
 }


### PR DESCRIPTION
This project seems to be outdated to the point it's no longer working. This PR fixes compatibility with current master of https://github.com/vpsfreecz/vpsadminos however I think there are more things to be updated since even the nixops went through major rewrite since this repository was originally created.

I was successful with deploying using `nixops 1.7` to freevps nixos (using current unstable channel `"21.03pre255377.11b75530a1f"`).

For the benefit of others this is all that's needed for deploying simple nginx with status page:

```nix
# vpsfree.nix - setting specific to deploying to vpsfree.cz
{
  network = {
    description = "<nice-description>";
  };

  vps = { config, pkgs, lib, ... }:
    let
      vpsadminos = builtins.fetchTarball https://github.com/vpsfreecz/vpsadminos/archive/master.tar.gz;
    in
    {
      imports = [
        <nixpkgs/nixos/modules/virtualisation/container-config.nix>
        "${vpsadminos}/os/lib/nixos-container/configuration.nix"
      ];
      deployment.targetHost = "<your-ip>";
    };
}
```

and finally the software definition itself:

```nix
# services.nix
{
  vps = { config, pkgs, nodes, ... }:
    {
      services.nginx = {
        enable = true;
        statusPage = true;
      };
      networking.firewall.allowedTCPPorts = [ 80 443 ];
    };
}
```

just a reminder how to use this:

```
$ nixops create services.nix vpsfree.nix -d vpsfree
$ nixops deploy -d vpsfree
```